### PR TITLE
Add setup script and new README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# SCRIPTS
+# DevOps Scripts Collection
+
+This repository contains handy shell scripts for setting up and managing
+common DevOps tools on Ubuntu-based systems.  Each script lives in the
+`scripts/` directory and can be run individually depending on your needs.
+
+## Available Scripts
+
+- **setup_devops.sh** – Installs Docker, AWS CLI, Terraform, Helm, kubectl,
+  Minikube and Ansible.  It also performs some housekeeping of old
+  repositories.
+
+## Usage
+
+Clone the repository and run the script you want.  For example:
+
+```bash
+./scripts/setup_devops.sh
+```
+
+Most scripts require root privileges for installing packages.  The
+`setup_devops.sh` script also adds the current user to the Docker group –
+log out and back in (or run `exec $SHELL`) afterwards.
+
+Feel free to copy or modify these scripts for your own projects.
+Contributions and suggestions are welcome!

--- a/README.md
+++ b/README.md
@@ -1,22 +1,32 @@
 # DevOps Scripts Collection
 
-This repository contains handy shell scripts for setting up and managing
-common DevOps tools on Ubuntu-based systems.  Each script lives in the
-`scripts/` directory and can be run individually depending on your needs.
+This repository provides handy shell scripts for installing and configuring
+popular DevOps tools on Ubuntu-based systems. Each script lives in the
+`scripts/` directory so you can easily add more utilities over time.
 
 ## Available Scripts
 
 - **setup_devops.sh** – Installs Docker, AWS CLI, Terraform, Helm, kubectl,
-  Minikube and Ansible.  It also performs some housekeeping of old
-  repositories.
+  Minikube and Ansible.  It also removes obsolete package entries so apt does
+  not complain during installation.
+
+### setup_devops.sh details
+
+This script performs the heavy lifting for a local DevOps workstation. It will
+install the tools listed above using the official package repositories where
+possible, falling back to standalone binaries if needed. The script is idempotent
+and skips tools that are already present on the system.
 
 ## Usage
 
-Clone the repository and run the script you want.  For example:
+Clone the repository and run the script you want. For example:
 
 ```bash
 ./scripts/setup_devops.sh
 ```
+
+Run `./scripts/setup_devops.sh --help` to see the available options and a
+short description of what the script does.
 
 Most scripts require root privileges for installing packages.  The
 `setup_devops.sh` script also adds the current user to the Docker group –

--- a/scripts/setup_devops.sh
+++ b/scripts/setup_devops.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+trap 'echo -e "\e[31m✗  Failed on line ${LINENO}"; exit 1' ERR
+shopt -s inherit_errexit
+
+GREEN='\033[0;32m'; NC='\033[0m'
+info(){ printf "${GREEN}==> %s${NC}\n" "$*"; }
+have(){ command -v "$1" &>/dev/null; }
+
+############################################################
+# 0. Prep & legacy-repo cleanup
+############################################################
+info "House-keeping & legacy-repo cleanup …"
+sudo rm -f /etc/apt/sources.list.d/kubernetes.list || true
+sudo sed -i '/apt\.kubernetes\.io/d' /etc/apt/sources.list || true
+sudo apt-get update -y
+sudo apt-get install -y ca-certificates curl gnupg lsb-release \
+                        unzip apt-transport-https software-properties-common
+
+############################################################
+# 1. Docker Engine + Compose
+############################################################
+if ! have docker; then
+  info "Installing Docker …"
+  sudo install -d -m0755 /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+    | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+  | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+  sudo apt-get update -y
+  sudo apt-get install -y docker-ce docker-ce-cli containerd.io \
+                          docker-buildx-plugin docker-compose-plugin
+  sudo usermod -aG docker "$USER"
+else info "Docker already present – skipping."; fi
+
+############################################################
+# 2. AWS CLI v2
+############################################################
+if ! have aws; then
+  info "Installing AWS CLI v2 …"
+  curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscli.zip
+  unzip -qq /tmp/awscli.zip -d /tmp && sudo /tmp/aws/install --update
+  rm -rf /tmp/aws /tmp/awscli.zip
+else info "AWS CLI already present – skipping."; fi
+
+############################################################
+# 3. Terraform
+############################################################
+if ! have terraform; then
+  info "Installing Terraform …"
+  sudo install -d -m0755 /etc/apt/keyrings
+  curl -fsSL https://apt.releases.hashicorp.com/gpg \
+    | sudo gpg --dearmor -o /etc/apt/keyrings/hashicorp.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/hashicorp.gpg] \
+https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
+  | sudo tee /etc/apt/sources.list.d/hashicorp.list >/dev/null
+  sudo apt-get update -y && sudo apt-get install -y terraform
+else info "Terraform already present – skipping."; fi
+
+############################################################
+# 4. Helm 3
+############################################################
+if ! have helm; then
+  info "Installing Helm …"
+  curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+else info "Helm already present – skipping."; fi
+
+############################################################
+# 5. kubectl (new pkgs.k8s.io repo, falls back to static binary)
+############################################################
+if ! have kubectl; then
+  info "Installing kubectl (pkgs.k8s.io) …"
+  sudo install -d -m0755 /etc/apt/keyrings
+  curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.33/deb/Release.key \
+    | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+  echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] \
+https://pkgs.k8s.io/core:/stable:/v1.33/deb/ /" \
+  | sudo tee /etc/apt/sources.list.d/kubernetes.list >/dev/null
+  if sudo apt-get update -y && sudo apt-get install -y kubectl; then
+    info "kubectl installed via APT."
+  else
+    info "APT failed – using standalone binary …"
+    curl -LO "https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+    chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+  fi
+else info "kubectl already present – skipping."; fi
+
+############################################################
+# 6. Minikube (local K8s cluster)
+############################################################
+if ! have minikube; then
+  info "Installing Minikube …"
+  curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+  chmod +x minikube && sudo mv minikube /usr/local/bin/
+else info "Minikube already present – skipping."; fi
+
+############################################################
+# 7. Ansible (Launchpad PPA)
+############################################################
+if ! have ansible; then
+  info "Installing Ansible …"
+  sudo add-apt-repository --yes --update ppa:ansible/ansible
+  sudo apt-get install -y ansible
+else info "Ansible already present – skipping."; fi
+
+############################################################
+# Done
+############################################################
+info "✅  All tools present!  Run:  exec \$SHELL  or reopen terminal for Docker group changes."
+info "   Next steps:"
+echo   "   • minikube start --driver=docker      # spin up a local K8s cluster"
+echo   "   • aws configure                       # add your AWS credentials"
+echo   "   • ansible --version                   # verify Ansible install"
+

--- a/scripts/setup_devops.sh
+++ b/scripts/setup_devops.sh
@@ -7,6 +7,22 @@ GREEN='\033[0;32m'; NC='\033[0m'
 info(){ printf "${GREEN}==> %s${NC}\n" "$*"; }
 have(){ command -v "$1" &>/dev/null; }
 
+usage(){
+  cat <<'EOF'
+Usage: setup_devops.sh [OPTION]
+
+Installs Docker, AWS CLI, Terraform, Helm, kubectl, Minikube and
+Ansible on Ubuntu-based systems.
+
+  -h, --help   Show this help message and exit
+EOF
+}
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  usage
+  exit 0
+fi
+
 ############################################################
 # 0. Prep & legacy-repo cleanup
 ############################################################


### PR DESCRIPTION
## Summary
- add a `setup_devops.sh` utility under `scripts/`
- rewrite README to explain the repo and new script

## Testing
- `bash scripts/setup_devops.sh --help` *(fails: no help available)*


------
https://chatgpt.com/codex/tasks/task_e_6863e6ecd2cc8327817d8e1581b14eb3